### PR TITLE
change!: use TOML instead of YAML as conversion parameters format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.0 (unreleased)
+
+### Breaking
+
+- Conversion parameters format is now TOML instead of YAML.
+
 ## 0.1.0 (2024-07-22)
 
 - Initial release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1945,6 +1945,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2049,7 +2058,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "svn2git"
-version = "0.1.0"
+version = "0.2.0-pre"
 dependencies = [
  "bzip2",
  "chrono",
@@ -2077,6 +2086,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "smallvec",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -2202,6 +2212,40 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "svn2git"
-version = "0.1.0"
+version = "0.2.0-pre"
 authors = ["Eduardo Sánchez Muñoz <eduardosm-dev@e64.io>"]
 edition = "2021"
 rust-version = "1.77"
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["converter", "git", "repository", "subversion", "svn"]
 categories = ["development-tools"]
 exclude = ["/.github", "/book", "/ci", ".gitignore"]
-publish = true
+publish = false
 
 [[test]]
 name = "convert"
@@ -37,8 +37,8 @@ lru-mem = "0.3.0"
 lz4_flex = "0.11.3"
 minijinja = "2.1.2"
 serde = { version = "1.0.205", features = ["derive"] }
-serde_yaml = "0.9.34"
 smallvec = "1.13.2"
+toml = "0.8.19"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 uuid = "1.10.0"
@@ -58,6 +58,7 @@ features = ["std"]
 gix = "0.64.0"
 libtest-mimic = "0.7.3"
 rand = "0.8.5"
+serde_yaml = "0.9.34"
 
 [profile.release]
 panic = "abort"

--- a/book/src/documentation/cli.md
+++ b/book/src/documentation/cli.md
@@ -36,7 +36,7 @@
 
 * `-P <FILE>` or `--conv-params <FILE>` (required)
 
-  Path to a file in YAML format used to configure the conversion. See the
+  Path to a file in TOML format used to configure the conversion. See the
   [Conversion Parameters](./conv-params.md) section.
 
 * `--obj-cache-size <SIZE>` (default: `384`)

--- a/book/src/documentation/conv-params.md
+++ b/book/src/documentation/conv-params.md
@@ -8,22 +8,24 @@
 
   <u>Example</u>
 
-  ```yaml
-  branches:
+  ```toml
+  branches = [
     # Consider "trunk" a branch.
-    - trunk
+    "trunk",
     # Consider each subdirectory in "branches" a branch.
-    - branches/*
+    "branches/*",
     # Do not consider "branches/more" a branch. Instead, consider each
     # subdirectory a branch.
-    - branches/more/*
+    "branches/more/*",
+  ]
 
-  tags:
+  tags = [
     # Consider each subdirectory in "tags" a tag.
-    - tags/*
+    "tags/*",
+  ]
   ```
 
-* `rename-branches` and `rename-tags` (default: empty array)
+* `rename-branches` and `rename-tags` (default: empty table)
 
   By default, branches and tags will have the SVN path as the name. These
   options allow specifying key-value maps to rename branches and tags.
@@ -32,16 +34,14 @@
 
   <u>Example</u>
 
-  ```yaml
-  rename-branches:
-    # Rename "trunk" to "master" (exact rename).
-    trunk: master
-    # Rename "branches/<name>" to "b-<name>" (prefix replacement).
-    branches/*: b-*
+  ```toml
+  # Rename "trunk" to "master" (exact rename).
+  rename-branches.trunk = "master"
+  # Rename "branches/<name>" to "b-<name>" (prefix replacement).
+  rename-branches."branches/*" = "b-*"
 
-  rename-tags:
-    # Rename "tags/<name>" to "<name>" (prefix replacement).
-    tags/*: "*"
+  # Rename "tags/<name>" to "<name>" (prefix replacement).
+  rename-tags."tags/*" = "*"
   ```
 
 * `keep-deleted-branches` and `keep-deleted-tags` (default: `true`)
@@ -51,9 +51,9 @@
 
   <u>Example</u>
 
-  ```yaml
-  keep-deleted-branches: false
-  keep-deleted-tags: false
+  ```toml
+  keep-deleted-branches = false
+  keep-deleted-tags = false
   ```
 
 * `head` (default: `trunk`)
@@ -64,9 +64,9 @@
 
   <u>Example</u>
 
-  ```yaml
+  ```toml
   # The branch whose SVN path is "trunk" will be used as Git HEAD.
-  head: trunk
+  head = "trunk"
   ```
 
   You can set it to an empty string to use the unbranched branch (see below) as
@@ -74,8 +74,8 @@
 
   <u>Example</u>
 
-  ```yaml
-  head: ""
+  ```toml
+  head = ""
   ```
 
 * `unbranched-name` (default: `unbranched`)
@@ -85,8 +85,8 @@
 
   <u>Example</u>
 
-  ```yaml
-  unbranched-name: unbranched
+  ```toml
+  unbranched-name = "unbranched"
   ```
 
 * `enable-merges` (default: `true`)
@@ -96,9 +96,9 @@
 
   <u>Example</u>
 
-  ```yaml
+  ```toml
   # Disable Git merges
-  enable-merges: false
+  enable-merges = "false"
   ```
 
 * `generate-gitignore` (default: `true`)
@@ -109,30 +109,31 @@
 
   <u>Example</u>
 
-  ```yaml
+  ```toml
   # Generate .gitignore files
-  generate-gitignore: true
+  generate-gitignore = "true"
   ```
 
 * `delete-files` (default: empty array)
 
-  Array of regular patterns that match paths of files that should be deleted.
+  Array of patterns that match paths of files that should be deleted.
 
   <u>Example</u>
 
-  ```yaml
-  delete-files:
+  ```toml
+  delete-files = [
     # Delete ".cvsignore" files (regardless of their location)
-    - "**/.cvsignore"
+    "**/.cvsignore",
+  ]
   ```
 
 * `user-map-file`
 
-  Specifies the path (relative to the location of the parameters YAML file)
+  Specifies the path (relative to the location of the parameters TOML file)
   which maps Subversion usernames to Git names/emails.
 
   <u>Example</u>
 
-  ```yaml
-  user-map-file: user-map.txt
+  ```toml
+  user-map-file = "user-map.txt"
   ```

--- a/book/src/tutorial/02-configure-conv.md
+++ b/book/src/tutorial/02-configure-conv.md
@@ -11,45 +11,43 @@ user1 = User One <user1@somewhere>
 user2 = User Two <user2@somewhere>
 ```
 
-And a YAML file with some configuration parameters (let's name it
-`my-conv-params.yaml`):
+And a TOML file with some configuration parameters (let's name it
+`my-conv-params.toml`):
 
-```yaml
+```toml
 # Specify which directories within the repository are considered branches
-branches:
+branches = [
   # "trunk" is a branch
-  - trunk
+  "trunk",
   # Each directory inside "branches" is a branch
-  - branches/*
+  "branches/*",
   # "branches/more_branches" is not a branch itself.
   # Instead, each subdirectory is a branch
-  - branches/more_branches/*
-
-rename-branches:
-  # Rename "trunk" branch to "master"
-  trunk: master
-  # Remove "branches/" prefix from all branches in "branches/"
-  branches/*: "*"
+  "branches/more_branches/*",
+]
+# Rename "trunk" branch to "master"
+rename-branches."trunk" = "master"
+# Remove "branches/" prefix from all branches in "branches/"
+rename-branches."branches/*" = "*"
 
 # Specify which directories within the repository are considered tags
-tags:
+tags = [
   # Each directory inside "tags" is a tag
-  - tags/*
-
-rename-tags:
-  # Remove "tags/" prefix from all tags in "tags/"
-  tags/*: "*"
+  "tags/*",
+]
+# Remove "tags/" prefix from all tags in "tags/"
+rename-tags."tags/*" = "*"
 
 # Specify the Subversion branch whose converted Git branch will become the Git
 # HEAD.
-head: trunk
+head = "trunk"
 
 # Specify the name of the Git branch where anything that is not part of a
 # Subversion branch or tag will be placed
-unbranched-name: unbranched
+unbranched-name = "unbranched"
 
 # Specify the file that maps Subversion users to Git names/emails.
-user-map-file: my-user-map.txt
+user-map-file = "my-user-map.txt"
 ```
 
 You can find more conversion parameters and their description in the

--- a/book/src/tutorial/03-run-conv.md
+++ b/book/src/tutorial/03-run-conv.md
@@ -5,7 +5,7 @@ following command (assuming you placed the dump and configuration files in the
 same directory):
 
 ```sh
-svn2git -s my-svn-dump.xz -d my-git-repo.git -P my-conv-params.yaml --log-file my-conv-log.log
+svn2git -s my-svn-dump.xz -d my-git-repo.git -P my-conv-params.toml --log-file my-conv-log.log
 ```
 
 It will create the Git repository at `my-git-repo.git` and a log file at

--- a/convert-tests/test.rs
+++ b/convert-tests/test.rs
@@ -23,7 +23,7 @@ pub(crate) fn run_test(test_path: &Path) -> Result<(), String> {
             .map_err(|e| format!("failed to write {user_map_path:?}: {e}"))?;
     }
 
-    let conv_params_path = temp_dir.join("conv-params.yaml");
+    let conv_params_path = temp_dir.join("conv-params.toml");
     std::fs::write(&conv_params_path, test_def.conv_params.as_bytes())
         .map_err(|e| format!("failed to write {conv_params_path:?}: {e}"))?;
 

--- a/convert-tests/tests/branches/branched-unbranched.yaml
+++ b/convert-tests/tests/branches/branched-unbranched.yaml
@@ -25,8 +25,7 @@ svn-revs:
         text: "z\n"
 
 conv-params: |
-  branches:
-   - trunk
+  branches = ["trunk"]
 
 logs: |
   D svn2git::convert::stage1: importing SVN revision 1

--- a/convert-tests/tests/branches/copy-nonbranch-to-one.yaml
+++ b/convert-tests/tests/branches/copy-nonbranch-to-one.yaml
@@ -24,11 +24,10 @@ svn-revs:
         copy-from-path: trunk
 
 conv-params: |
-  branches:
-    - branches/*
-  rename-branches:
-    branches/*: "*"
-  head: branches/b1
+  branches = ["branches/*"]
+  rename-branches."branches/*" = "*"
+
+  head = "branches/b1"
 
 logs: |
   D svn2git::convert::stage1: importing SVN revision 3

--- a/convert-tests/tests/branches/copy-nonbranch-to-parent.yaml
+++ b/convert-tests/tests/branches/copy-nonbranch-to-parent.yaml
@@ -28,9 +28,8 @@ svn-revs:
         copy-from-path: branches1
 
 conv-params: |
-  branches:
-    - branches2/*
-  head: branches2/b1
+  branches = ["branches2/*"]
+  head = "branches2/b1"
 
 logs: |
   D svn2git::convert::stage1: importing SVN revision 2

--- a/convert-tests/tests/branches/copy-one-to-nonbranch.yaml
+++ b/convert-tests/tests/branches/copy-one-to-nonbranch.yaml
@@ -24,10 +24,8 @@ svn-revs:
         copy-from-path: trunk
 
 conv-params: |
-  branches:
-    - trunk
-  rename-branches:
-    trunk: master
+  branches = ["trunk"]
+  rename-branches."trunk" = "master"
 
 logs: |
   D svn2git::convert::stage1: importing SVN revision 3

--- a/convert-tests/tests/branches/copy-one.yaml
+++ b/convert-tests/tests/branches/copy-one.yaml
@@ -24,12 +24,12 @@ svn-revs:
         copy-from-path: trunk
 
 conv-params: |
-  branches:
-    - trunk
-    - branches/*
-  rename-branches:
-    trunk: master
-    branches/*: "*"
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."trunk" = "master"
+  rename-branches."branches/*" = "*"
 
 logs: |
   D svn2git::convert::stage1: importing SVN revision 3

--- a/convert-tests/tests/branches/copy-parent-to-nonbranch.yaml
+++ b/convert-tests/tests/branches/copy-parent-to-nonbranch.yaml
@@ -28,9 +28,8 @@ svn-revs:
         copy-from-path: branches1
 
 conv-params: |
-  branches:
-    - branches1/*
-  head: branches1/b1
+  branches = ["branches1/*"]
+  head = "branches1/b1"
 
 logs: |
   D svn2git::convert::stage1: importing SVN revision 2

--- a/convert-tests/tests/branches/copy-parent.yaml
+++ b/convert-tests/tests/branches/copy-parent.yaml
@@ -28,10 +28,11 @@ svn-revs:
         copy-from-path: branches1
 
 conv-params: |
-  branches:
-    - branches1/*
-    - branches2/*
-  head: branches1/b1
+  branches = [
+    "branches1/*",
+    "branches2/*",
+  ]
+  head = "branches1/b1"
 
 logs: |
   D svn2git::convert::stage1: importing SVN revision 2

--- a/convert-tests/tests/branches/copy-replace-parent.yaml
+++ b/convert-tests/tests/branches/copy-replace-parent.yaml
@@ -42,10 +42,11 @@ svn-revs:
         copy-from-path: branches1
 
 conv-params: |
-  branches:
-    - branches1/*
-    - branches2/*
-  head: branches1/b1
+  branches = [
+    "branches1/*",
+    "branches2/*",
+  ]
+  head = "branches1/b1"
 
 logs: |
   D svn2git::convert::stage1: importing SVN revision 3

--- a/convert-tests/tests/branches/delete-keep.yaml
+++ b/convert-tests/tests/branches/delete-keep.yaml
@@ -20,8 +20,7 @@ svn-revs:
         action: delete
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 logs: |
   D svn2git::convert::stage1: importing SVN revision 3

--- a/convert-tests/tests/branches/delete-not-keep.yaml
+++ b/convert-tests/tests/branches/delete-not-keep.yaml
@@ -30,13 +30,14 @@ svn-revs:
         action: delete
 
 conv-params: |
-  branches:
-    - trunk
-    - branches/*
-  rename-branches:
-    branches/*: "*"
-  keep-deleted-branches: false
-  head: "branches/b1"
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."branches/*" = "*"
+
+  keep-deleted-branches = false
+  head = "branches/b1"
 
 logs: |
   D svn2git::convert::stage1: importing SVN revision 3

--- a/convert-tests/tests/branches/delete-twice.yaml
+++ b/convert-tests/tests/branches/delete-twice.yaml
@@ -36,8 +36,7 @@ svn-revs:
         action: delete
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 logs: |
   D svn2git::convert::stage1: importing SVN revision 3

--- a/convert-tests/tests/branches/merge-after-cherrypick.yaml
+++ b/convert-tests/tests/branches/merge-after-cherrypick.yaml
@@ -75,12 +75,12 @@ svn-revs:
         text: "file D\n"
 
 conv-params: |
-  branches:
-    - trunk
-    - branches/*
-  rename-branches:
-    trunk: master
-    branches/*: "*"
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."trunk" = "master"
+  rename-branches."branches/*" = "*"
 
 logs: |
   D svn2git::convert::stage2: emitting branch commits and tags for SVN revision 7

--- a/convert-tests/tests/branches/merge-allowed-gap.yaml
+++ b/convert-tests/tests/branches/merge-allowed-gap.yaml
@@ -51,14 +51,16 @@ svn-revs:
         text: "file B\n"
 
 conv-params: |
-  branches:
-    - trunk
-    - branches/*
-  rename-branches:
-    trunk: master
-    branches/*: "*"
-  merge-optional:
-    - "**/A"
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."trunk" = "master"
+  rename-branches."branches/*" = "*"
+
+  merge-optional = [
+    "**/A",
+  ]
 
 logs: |
   D svn2git::convert::stage2: emitting branch commits and tags for SVN revision 6

--- a/convert-tests/tests/branches/merge-and-keep.yaml
+++ b/convert-tests/tests/branches/merge-and-keep.yaml
@@ -61,13 +61,14 @@ svn-revs:
         text: "file D\n"
 
 conv-params: |
-  branches:
-    - trunk
-    - branches/*
-  rename-branches:
-    trunk: master
-    branches/*: "*"
-  avoid-fully-reverted-merges: true
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."trunk" = "master"
+  rename-branches."branches/*" = "*"
+
+  avoid-fully-reverted-merges = true
 
 logs: |
   D svn2git::convert::stage2: emitting branch commits and tags for SVN revision 6

--- a/convert-tests/tests/branches/merge-and-revert-keep.yaml
+++ b/convert-tests/tests/branches/merge-and-revert-keep.yaml
@@ -61,13 +61,14 @@ svn-revs:
         action: delete
 
 conv-params: |
-  branches:
-    - trunk
-    - branches/*
-  rename-branches:
-    trunk: master
-    branches/*: "*"
-  avoid-fully-reverted-merges: false
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."trunk" = "master"
+  rename-branches."branches/*" = "*"
+
+  avoid-fully-reverted-merges = false
 
 logs: |
   D svn2git::convert::stage2: emitting branch commits and tags for SVN revision 6

--- a/convert-tests/tests/branches/merge-and-revert-not-keep.yaml
+++ b/convert-tests/tests/branches/merge-and-revert-not-keep.yaml
@@ -61,13 +61,14 @@ svn-revs:
         action: delete
 
 conv-params: |
-  branches:
-    - trunk
-    - branches/*
-  rename-branches:
-    trunk: master
-    branches/*: "*"
-  avoid-fully-reverted-merges: true
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."trunk" = "master"
+  rename-branches."branches/*" = "*"
+
+  avoid-fully-reverted-merges = true
 
 git-revs:
   - rev: master~4

--- a/convert-tests/tests/branches/merge-during-create.yaml
+++ b/convert-tests/tests/branches/merge-during-create.yaml
@@ -52,12 +52,12 @@ svn-revs:
         text: "file C\n"
 
 conv-params: |
-  branches:
-    - trunk
-    - branches/*
-  rename-branches:
-    trunk: master
-    branches/*: "*"
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."trunk" = "master"
+  rename-branches."branches/*" = "*"
 
 logs: |
   D svn2git::convert::stage2: emitting branch commits and tags for SVN revision 6

--- a/convert-tests/tests/branches/merge-simple-ignore.yaml
+++ b/convert-tests/tests/branches/merge-simple-ignore.yaml
@@ -51,15 +51,17 @@ svn-revs:
         text: "file C\n"
 
 conv-params: |
-  branches:
-    - trunk
-    - branches/*
-  rename-branches:
-    trunk: master
-    branches/*: "*"
-  ignore-merges:
-    - path: trunk
-      rev: 6
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."trunk" = "master"
+  rename-branches."branches/*" = "*"
+
+
+  ignore-merges = [
+    { path = "trunk", rev = 6 },
+  ]
 
 git-revs:
   - rev: master~3

--- a/convert-tests/tests/branches/merge-simple.yaml
+++ b/convert-tests/tests/branches/merge-simple.yaml
@@ -51,12 +51,12 @@ svn-revs:
         text: "file C\n"
 
 conv-params: |
-  branches:
-    - trunk
-    - branches/*
-  rename-branches:
-    trunk: master
-    branches/*: "*"
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."trunk" = "master"
+  rename-branches."branches/*" = "*"
 
 logs: |
   D svn2git::convert::stage2: emitting branch commits and tags for SVN revision 6

--- a/convert-tests/tests/branches/merge-twice.yaml
+++ b/convert-tests/tests/branches/merge-twice.yaml
@@ -64,12 +64,12 @@ svn-revs:
         text: "file C\n"
 
 conv-params: |
-  branches:
-  - trunk
-  - branches/*
-  rename-branches:
-    trunk: master
-    branches/*: "*"
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."trunk" = "master"
+  rename-branches."branches/*" = "*"
 
 logs: |
   D svn2git::convert::stage2: emitting branch commits and tags for SVN revision 6

--- a/convert-tests/tests/branches/merge-with-cherrypick.yaml
+++ b/convert-tests/tests/branches/merge-with-cherrypick.yaml
@@ -90,12 +90,12 @@ svn-revs:
         text: "file E\n"
 
 conv-params: |
-  branches:
-    - trunk
-    - branches/*
-  rename-branches:
-    trunk: master
-    branches/*: "*"
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."trunk" = "master"
+  rename-branches."branches/*" = "*"
 
 logs: |
   D svn2git::convert::stage2: emitting branch commits and tags for SVN revision 9

--- a/convert-tests/tests/branches/not-merge-gap.yaml
+++ b/convert-tests/tests/branches/not-merge-gap.yaml
@@ -51,12 +51,12 @@ svn-revs:
         text: "file C\n"
 
 conv-params: |
-  branches:
-    - trunk
-    - branches/*
-  rename-branches:
-    trunk: master
-    branches/*: "*"
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."trunk" = "master"
+  rename-branches."branches/*" = "*"
 
 git-revs:
   - rev: master~2

--- a/convert-tests/tests/branches/recover-one.yaml
+++ b/convert-tests/tests/branches/recover-one.yaml
@@ -25,10 +25,11 @@ svn-revs:
         copy-from-path: trunk
 
 conv-params: |
-  branches:
-    - trunk
-    - trunk2
-  head: trunk2
+  branches = [
+    "trunk",
+    "trunk2",
+  ]
+  head = "trunk2"
 
 git-revs:
   - rev: deleted/trunk~0

--- a/convert-tests/tests/branches/recover-parent.yaml
+++ b/convert-tests/tests/branches/recover-parent.yaml
@@ -35,10 +35,11 @@ svn-revs:
         copy-from-path: branches1
 
 conv-params: |
-  branches:
-    - branches1/*
-    - branches2/*
-  head: branches2/b1
+  branches = [
+    "branches1/*",
+    "branches2/*",
+  ]
+  head = "branches2/b1"
 
 git-revs:
   - rev: deleted/branches1/b1~0

--- a/convert-tests/tests/branches/recreate.yaml
+++ b/convert-tests/tests/branches/recreate.yaml
@@ -27,8 +27,7 @@ svn-revs:
         text: "y\n"
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 logs: |
   D svn2git::convert::stage1: importing SVN revision 3

--- a/convert-tests/tests/branches/unbranched-custom.yaml
+++ b/convert-tests/tests/branches/unbranched-custom.yaml
@@ -15,8 +15,8 @@ svn-revs:
         text: "y\n"
 
 conv-params: |
-  head: ""
-  unbranched-name: onebranch
+  head = ""
+  unbranched-name = "onebranch"
 
 git-revs:
   - rev: onebranch~1

--- a/convert-tests/tests/commit-meta/crlf.yaml
+++ b/convert-tests/tests/commit-meta/crlf.yaml
@@ -13,8 +13,7 @@ svn-revs:
         text: "x\n"
 
 conv-params: |
-  branches:
-   - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~0

--- a/convert-tests/tests/commit-meta/custom.yaml
+++ b/convert-tests/tests/commit-meta/custom.yaml
@@ -26,17 +26,17 @@ svn-revs:
         text: "y\n"
 
 conv-params: |
-  branches:
-   - trunk
-  user-map-file: user-map.txt
-  user-fallback-template: "{{ svn_author }} <unknown>"
-  commit-msg-template: |
-    uuid: {{ svn_uuid }}
-    author: {{ svn_author }}{% if mapped_author_name %}
-    mapped_author_name: {{ mapped_author_name }}{% endif %}{% if mapped_author_email %}
-    mapped_author_email: {{ mapped_author_email }}{% endif %}
-    log: {{ svn_log }}
-    path: {% if svn_path %}{{ svn_path }}{% else %}<none>{% endif %}
+  branches = ["trunk"]
+  user-map-file = "user-map.txt"
+  user-fallback-template = "{{ svn_author }} <unknown>"
+  commit-msg-template = """
+  uuid: {{ svn_uuid }}
+  author: {{ svn_author }}{% if mapped_author_name %}
+  mapped_author_name: {{ mapped_author_name }}{% endif %}{% if mapped_author_email %}
+  mapped_author_email: {{ mapped_author_email }}{% endif %}
+  log: {{ svn_log }}
+  path: {% if svn_path %}{{ svn_path }}{% else %}<none>{% endif %}
+  """
 
 user-map: |
   user1 = User 1 <user1@somewhere>

--- a/convert-tests/tests/commit-meta/default.yaml
+++ b/convert-tests/tests/commit-meta/default.yaml
@@ -35,8 +35,7 @@ svn-revs:
         text: "z\n"
 
 conv-params: |
-  branches:
-   - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~2

--- a/convert-tests/tests/copy-root.yaml
+++ b/convert-tests/tests/copy-root.yaml
@@ -28,12 +28,13 @@ svn-revs:
         copy-from-path: ""
 
 conv-params: |
-  branches:
-    - branches/*
-    - backup/branches/*
-  rename-branches:
-    branches/*: "*"
-  head: branches/b1
+  branches = [
+    "branches/*",
+    "backup/branches/*",
+  ]
+  rename-branches."branches/*" = "*"
+
+  head = "branches/b1"
 
 git-revs:
   - rev: b1~0

--- a/convert-tests/tests/delete-files-branched.yaml
+++ b/convert-tests/tests/delete-files-branched.yaml
@@ -22,10 +22,8 @@ svn-revs:
         copy-from-path: trunk/y
 
 conv-params: |
-  branches:
-    - trunk
-  delete-files:
-    - "**/y"
+  branches = ["trunk"]
+  delete-files = ["**/y"]
 
 git-revs:
   - rev: trunk~1

--- a/convert-tests/tests/delete-files-unbranched.yaml
+++ b/convert-tests/tests/delete-files-unbranched.yaml
@@ -19,9 +19,8 @@ svn-revs:
         copy-from-path: y
 
 conv-params: |
-  head: ""
-  delete-files:
-    - "**/y"
+  head = ""
+  delete-files = ["**/y"]
 
 git-revs:
   - rev: unbranched~1

--- a/convert-tests/tests/dump-sources/compressed-bzip2.yaml
+++ b/convert-tests/tests/dump-sources/compressed-bzip2.yaml
@@ -20,8 +20,7 @@ svn-revs:
         text: "y\n"
 
 conv-params: |
-  branches:
-   - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~0

--- a/convert-tests/tests/dump-sources/compressed-gzip.yaml
+++ b/convert-tests/tests/dump-sources/compressed-gzip.yaml
@@ -20,8 +20,7 @@ svn-revs:
         text: "y\n"
 
 conv-params: |
-  branches:
-   - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~0

--- a/convert-tests/tests/dump-sources/compressed-lz4.yaml
+++ b/convert-tests/tests/dump-sources/compressed-lz4.yaml
@@ -20,8 +20,7 @@ svn-revs:
         text: "y\n"
 
 conv-params: |
-  branches:
-   - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~0

--- a/convert-tests/tests/dump-sources/compressed-xz.yaml
+++ b/convert-tests/tests/dump-sources/compressed-xz.yaml
@@ -20,8 +20,7 @@ svn-revs:
         text: "y\n"
 
 conv-params: |
-  branches:
-   - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~0

--- a/convert-tests/tests/dump-sources/compressed-zstd.yaml
+++ b/convert-tests/tests/dump-sources/compressed-zstd.yaml
@@ -20,8 +20,7 @@ svn-revs:
         text: "y\n"
 
 conv-params: |
-  branches:
-   - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~0

--- a/convert-tests/tests/dump-sources/uncompressed.yaml
+++ b/convert-tests/tests/dump-sources/uncompressed.yaml
@@ -20,8 +20,7 @@ svn-revs:
         text: "y\n"
 
 conv-params: |
-  branches:
-   - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~0

--- a/convert-tests/tests/fail/change-non-existing-file.yaml
+++ b/convert-tests/tests/fail/change-non-existing-file.yaml
@@ -14,8 +14,7 @@ svn-revs:
         text: "x\n"
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 failed: true
 

--- a/convert-tests/tests/fail/copy-file-as-dir.yaml
+++ b/convert-tests/tests/fail/copy-file-as-dir.yaml
@@ -18,8 +18,7 @@ svn-revs:
         copy-from-path: trunk/x
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 failed: true
 

--- a/convert-tests/tests/fail/copy-from-non-existing-path.yaml
+++ b/convert-tests/tests/fail/copy-from-non-existing-path.yaml
@@ -15,8 +15,7 @@ svn-revs:
         copy-from-path: trunk/y
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 failed: true
 

--- a/convert-tests/tests/fail/copy-from-non-existing-rev.yaml
+++ b/convert-tests/tests/fail/copy-from-non-existing-rev.yaml
@@ -15,8 +15,7 @@ svn-revs:
         copy-from-path: trunk/y
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 failed: true
 

--- a/convert-tests/tests/fail/delete-non-existing-file.yaml
+++ b/convert-tests/tests/fail/delete-non-existing-file.yaml
@@ -13,8 +13,7 @@ svn-revs:
         action: delete
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 failed: true
 

--- a/convert-tests/tests/fail/delete-with-copy-from.yaml
+++ b/convert-tests/tests/fail/delete-with-copy-from.yaml
@@ -18,8 +18,7 @@ svn-revs:
         copy-from-path: trunk/x
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 failed: true
 

--- a/convert-tests/tests/fail/delete-with-text.yaml
+++ b/convert-tests/tests/fail/delete-with-text.yaml
@@ -18,8 +18,7 @@ svn-revs:
         text: "x\n"
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 failed: true
 

--- a/convert-tests/tests/fail/deleted-head.yaml
+++ b/convert-tests/tests/fail/deleted-head.yaml
@@ -33,13 +33,14 @@ svn-revs:
         action: delete
 
 conv-params: |
-  branches:
-    - trunk
-    - branches/*
-  rename-branches:
-    trunk: master
-    branches/*: "*"
-  keep-deleted-branches: false
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."trunk" = "master"
+  rename-branches."branches/*" = "*"
+
+  keep-deleted-branches = false
 
 logs: |
   E svn2git::convert::stage1: head "trunk" has been removed

--- a/convert-tests/tests/fail/missing-file-add-text.yaml
+++ b/convert-tests/tests/fail/missing-file-add-text.yaml
@@ -10,8 +10,7 @@ svn-revs:
         action: add
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 failed: true
 

--- a/convert-tests/tests/fail/missing-file-replace-text.yaml
+++ b/convert-tests/tests/fail/missing-file-replace-text.yaml
@@ -20,8 +20,7 @@ svn-revs:
         action: replace
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 failed: true
 

--- a/convert-tests/tests/fail/replace-non-existing-file.yaml
+++ b/convert-tests/tests/fail/replace-non-existing-file.yaml
@@ -14,8 +14,7 @@ svn-revs:
         text: "x\n"
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 failed: true
 

--- a/convert-tests/tests/fail/tag-head.yaml
+++ b/convert-tests/tests/fail/tag-head.yaml
@@ -24,15 +24,13 @@ svn-revs:
         copy-from-path: trunk
 
 conv-params: |
-  branches:
-    - trunk
-  tags:
-    - tags/*
-  rename-branches:
-    trunk: master
-  rename-tags:
-    tags/*: "*"
-  head: tags/t1
+  branches = ["trunk"]
+  rename-branches."trunk" = "master"
+
+  tags = ["tags/*"]
+  rename-tags."tags/*" = "*"
+
+  head = "tags/t1"
 
 logs: |
   E svn2git::convert::stage1: head "tags/t1" is a tag

--- a/convert-tests/tests/git-repack.yaml
+++ b/convert-tests/tests/git-repack.yaml
@@ -18,8 +18,7 @@ svn-revs:
         text: "y\n"
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 git-repack: true
 

--- a/convert-tests/tests/head/custom-branch.yaml
+++ b/convert-tests/tests/head/custom-branch.yaml
@@ -27,13 +27,14 @@ svn-revs:
         text: "y\n"
 
 conv-params: |
-  branches:
-    - trunk
-    - branches/*
-  rename-branches:
-    trunk: master
-    branches/*: "*"
-  head: branches/b1
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."trunk" = "master"
+  rename-branches."branches/*" = "*"
+
+  head = "branches/b1"
 
 git-revs:
   - rev: HEAD

--- a/convert-tests/tests/head/default.yaml
+++ b/convert-tests/tests/head/default.yaml
@@ -27,12 +27,12 @@ svn-revs:
         text: "y\n"
 
 conv-params: |
-  branches:
-    - trunk
-    - branches/*
-  rename-branches:
-    trunk: master
-    branches/*: "*"
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."trunk" = "master"
+  rename-branches."branches/*" = "*"
 
 git-revs:
   - rev: HEAD

--- a/convert-tests/tests/head/deleted-keep.yaml
+++ b/convert-tests/tests/head/deleted-keep.yaml
@@ -33,12 +33,12 @@ svn-revs:
         action: delete
 
 conv-params: |
-  branches:
-    - trunk
-    - branches/*
-  rename-branches:
-    trunk: master
-    branches/*: "*"
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."trunk" = "master"
+  rename-branches."branches/*" = "*"
 
 git-revs:
   - rev: HEAD

--- a/convert-tests/tests/head/explicit-trunk.yaml
+++ b/convert-tests/tests/head/explicit-trunk.yaml
@@ -27,13 +27,14 @@ svn-revs:
         text: "y\n"
 
 conv-params: |
-  branches:
-    - trunk
-    - branches/*
-  rename-branches:
-    trunk: master
-    branches/*: "*"
-  head: trunk
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."trunk" = "master"
+  rename-branches."branches/*" = "*"
+
+  head = "trunk"
 
 git-revs:
   - rev: HEAD

--- a/convert-tests/tests/head/unbranched-custom.yaml
+++ b/convert-tests/tests/head/unbranched-custom.yaml
@@ -15,8 +15,8 @@ svn-revs:
         text: "y\n"
 
 conv-params: |
-  head: ""
-  unbranched-name: master
+  head = ""
+  unbranched-name = "master"
 
 git-revs:
   - rev: HEAD

--- a/convert-tests/tests/head/unbranched.yaml
+++ b/convert-tests/tests/head/unbranched.yaml
@@ -15,7 +15,7 @@ svn-revs:
         text: "y\n"
 
 conv-params: |
-  head: ""
+  head = ""
 
 git-revs:
   - rev: HEAD

--- a/convert-tests/tests/ignore/branched.yaml
+++ b/convert-tests/tests/ignore/branched.yaml
@@ -59,8 +59,7 @@ svn-revs:
         props: {}
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~5

--- a/convert-tests/tests/ignore/disabled-branched.yaml
+++ b/convert-tests/tests/ignore/disabled-branched.yaml
@@ -59,9 +59,8 @@ svn-revs:
         props: {}
 
 conv-params: |
-  branches:
-    - trunk
-  generate-gitignore: false
+  branches = ["trunk"]
+  generate-gitignore = false
 
 git-revs:
   - rev: trunk~5

--- a/convert-tests/tests/ignore/disabled-unbranched.yaml
+++ b/convert-tests/tests/ignore/disabled-unbranched.yaml
@@ -69,9 +69,8 @@ svn-revs:
         props: {}
 
 conv-params: |
-  branches:
-    - trunk
-  generate-gitignore: false
+  branches = ["trunk"]
+  generate-gitignore = false
 
 git-revs:
   - rev: trunk~0

--- a/convert-tests/tests/ignore/unbranched.yaml
+++ b/convert-tests/tests/ignore/unbranched.yaml
@@ -69,8 +69,7 @@ svn-revs:
         props: {}
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~0

--- a/convert-tests/tests/ops-branched/basic.yaml
+++ b/convert-tests/tests/ops-branched/basic.yaml
@@ -18,8 +18,7 @@ svn-revs:
         text: "y\n"
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~0

--- a/convert-tests/tests/ops-branched/change-file-exec.yaml
+++ b/convert-tests/tests/ops-branched/change-file-exec.yaml
@@ -50,8 +50,7 @@ svn-revs:
         text: "4\n"
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~5

--- a/convert-tests/tests/ops-branched/copy-dir.yaml
+++ b/convert-tests/tests/ops-branched/copy-dir.yaml
@@ -21,8 +21,7 @@ svn-revs:
         copy-from-path: trunk/dir
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~1

--- a/convert-tests/tests/ops-branched/copy-file.yaml
+++ b/convert-tests/tests/ops-branched/copy-file.yaml
@@ -18,8 +18,7 @@ svn-revs:
         copy-from-path: trunk/x
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~1

--- a/convert-tests/tests/ops-branched/copy-modify-file.yaml
+++ b/convert-tests/tests/ops-branched/copy-modify-file.yaml
@@ -19,8 +19,7 @@ svn-revs:
         text: "modified\n"
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~1

--- a/convert-tests/tests/ops-branched/copy-replace-file.yaml
+++ b/convert-tests/tests/ops-branched/copy-replace-file.yaml
@@ -22,8 +22,7 @@ svn-revs:
         copy-from-path: trunk/x
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~1

--- a/convert-tests/tests/ops-branched/copy-replace-modify-file.yaml
+++ b/convert-tests/tests/ops-branched/copy-replace-modify-file.yaml
@@ -23,8 +23,7 @@ svn-revs:
         text: "file 3\n"
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~1

--- a/convert-tests/tests/ops-branched/delete-dir.yaml
+++ b/convert-tests/tests/ops-branched/delete-dir.yaml
@@ -20,8 +20,7 @@ svn-revs:
         action: delete
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~1

--- a/convert-tests/tests/ops-branched/delete-file.yaml
+++ b/convert-tests/tests/ops-branched/delete-file.yaml
@@ -17,8 +17,7 @@ svn-revs:
         action: delete
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~1

--- a/convert-tests/tests/ops-branched/file-to-symlink.yaml
+++ b/convert-tests/tests/ops-branched/file-to-symlink.yaml
@@ -47,8 +47,7 @@ svn-revs:
         text: "link target3"
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~4

--- a/convert-tests/tests/ops-branched/modify-file.yaml
+++ b/convert-tests/tests/ops-branched/modify-file.yaml
@@ -18,8 +18,7 @@ svn-revs:
         text: "modified\n"
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~1

--- a/convert-tests/tests/ops-branched/replace-file.yaml
+++ b/convert-tests/tests/ops-branched/replace-file.yaml
@@ -18,8 +18,7 @@ svn-revs:
         text: "replaced\n"
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~1

--- a/convert-tests/tests/ops-unbranched/basic.yaml
+++ b/convert-tests/tests/ops-unbranched/basic.yaml
@@ -15,7 +15,7 @@ svn-revs:
         text: "y\n"
 
 conv-params: |
-  head: ""
+  head = ""
 
 git-revs:
   - rev: unbranched~0

--- a/convert-tests/tests/ops-unbranched/change-file-exec.yaml
+++ b/convert-tests/tests/ops-unbranched/change-file-exec.yaml
@@ -47,7 +47,7 @@ svn-revs:
         text: "4\n"
 
 conv-params: |
-  head: ""
+  head = ""
 
 git-revs:
   - rev: unbranched~5

--- a/convert-tests/tests/ops-unbranched/copy-dir.yaml
+++ b/convert-tests/tests/ops-unbranched/copy-dir.yaml
@@ -18,7 +18,7 @@ svn-revs:
         copy-from-path: dir
 
 conv-params: |
-  head: ""
+  head = ""
 
 git-revs:
   - rev: unbranched~1

--- a/convert-tests/tests/ops-unbranched/copy-file.yaml
+++ b/convert-tests/tests/ops-unbranched/copy-file.yaml
@@ -15,7 +15,7 @@ svn-revs:
         copy-from-path: x
 
 conv-params: |
-  head: ""
+  head = ""
 
 git-revs:
   - rev: unbranched~1

--- a/convert-tests/tests/ops-unbranched/copy-modify-file.yaml
+++ b/convert-tests/tests/ops-unbranched/copy-modify-file.yaml
@@ -16,7 +16,7 @@ svn-revs:
         text: "modified\n"
 
 conv-params: |
-  head: ""
+  head = ""
 
 git-revs:
   - rev: unbranched~1

--- a/convert-tests/tests/ops-unbranched/copy-replace-file.yaml
+++ b/convert-tests/tests/ops-unbranched/copy-replace-file.yaml
@@ -19,7 +19,7 @@ svn-revs:
         copy-from-path: x
 
 conv-params: |
-  head: ""
+  head = ""
 
 git-revs:
   - rev: unbranched~1

--- a/convert-tests/tests/ops-unbranched/copy-replace-modify-file.yaml
+++ b/convert-tests/tests/ops-unbranched/copy-replace-modify-file.yaml
@@ -20,7 +20,7 @@ svn-revs:
         text: "file 3\n"
 
 conv-params: |
-  head: ""
+  head = ""
 
 git-revs:
   - rev: unbranched~1

--- a/convert-tests/tests/ops-unbranched/delete-dir.yaml
+++ b/convert-tests/tests/ops-unbranched/delete-dir.yaml
@@ -17,7 +17,7 @@ svn-revs:
         action: delete
 
 conv-params: |
-  head: ""
+  head = ""
 
 git-revs:
   - rev: unbranched~1

--- a/convert-tests/tests/ops-unbranched/delete-file.yaml
+++ b/convert-tests/tests/ops-unbranched/delete-file.yaml
@@ -17,7 +17,7 @@ svn-revs:
         action: delete
 
 conv-params: |
-  head: ""
+  head = ""
 
 git-revs:
   - rev: unbranched~1

--- a/convert-tests/tests/ops-unbranched/file-to-symlink.yaml
+++ b/convert-tests/tests/ops-unbranched/file-to-symlink.yaml
@@ -47,7 +47,7 @@ svn-revs:
         text: "link target3"
 
 conv-params: |
-  head: ""
+  head = ""
 
 git-revs:
   - rev: unbranched~4

--- a/convert-tests/tests/ops-unbranched/modify-file.yaml
+++ b/convert-tests/tests/ops-unbranched/modify-file.yaml
@@ -15,7 +15,7 @@ svn-revs:
         text: "modified\n"
 
 conv-params: |
-  head: ""
+  head = ""
 
 git-revs:
   - rev: unbranched~1

--- a/convert-tests/tests/ops-unbranched/replace-file.yaml
+++ b/convert-tests/tests/ops-unbranched/replace-file.yaml
@@ -15,7 +15,7 @@ svn-revs:
         text: "replaced\n"
 
 conv-params: |
-  head: ""
+  head = ""
 
 git-revs:
   - rev: unbranched~1

--- a/convert-tests/tests/prop-delta/change-file-exec.yaml
+++ b/convert-tests/tests/prop-delta/change-file-exec.yaml
@@ -57,8 +57,7 @@ svn-revs:
         text: "4\n"
 
 conv-params: |
-  branches:
-   - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~5

--- a/convert-tests/tests/prop-delta/ignore-branched.yaml
+++ b/convert-tests/tests/prop-delta/ignore-branched.yaml
@@ -57,8 +57,7 @@ svn-revs:
           svn:global-ignores: null
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~4

--- a/convert-tests/tests/prop-delta/ignore-unbranched.yaml
+++ b/convert-tests/tests/prop-delta/ignore-unbranched.yaml
@@ -67,8 +67,7 @@ svn-revs:
           svn:global-ignores: null
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~0

--- a/convert-tests/tests/prop-delta/merge-and-keep.yaml
+++ b/convert-tests/tests/prop-delta/merge-and-keep.yaml
@@ -65,13 +65,14 @@ svn-revs:
         text: "file D\n"
 
 conv-params: |
-  branches:
-    - trunk
-    - branches/*
-  rename-branches:
-    trunk: master
-    branches/*: "*"
-  avoid-fully-reverted-merges: true
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."trunk" = "master"
+  rename-branches."branches/*" = "*"
+
+  avoid-fully-reverted-merges = true
 
 git-revs:
   - rev: master~4

--- a/convert-tests/tests/prop-delta/merge-and-revert-keep.yaml
+++ b/convert-tests/tests/prop-delta/merge-and-revert-keep.yaml
@@ -65,13 +65,14 @@ svn-revs:
         action: delete
 
 conv-params: |
-  branches:
-    - trunk
-    - branches/*
-  rename-branches:
-    trunk: master
-    branches/*: "*"
-  avoid-fully-reverted-merges: false
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."trunk" = "master"
+  rename-branches."branches/*" = "*"
+
+  avoid-fully-reverted-merges = false
 
 git-revs:
   - rev: master~4

--- a/convert-tests/tests/prop-delta/merge-and-revert-not-keep.yaml
+++ b/convert-tests/tests/prop-delta/merge-and-revert-not-keep.yaml
@@ -65,13 +65,14 @@ svn-revs:
         action: delete
 
 conv-params: |
-  branches:
-    - trunk
-    - branches/*
-  rename-branches:
-    trunk: master
-    branches/*: "*"
-  avoid-fully-reverted-merges: true
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."trunk" = "master"
+  rename-branches."branches/*" = "*"
+
+  avoid-fully-reverted-merges = true
 
 git-revs:
   - rev: master~4

--- a/convert-tests/tests/symlink.yaml
+++ b/convert-tests/tests/symlink.yaml
@@ -20,8 +20,7 @@ svn-revs:
         text: "link target2"
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~1

--- a/convert-tests/tests/tags/branch-from-tag.yaml
+++ b/convert-tests/tests/tags/branch-from-tag.yaml
@@ -34,16 +34,15 @@ svn-revs:
         copy-from-path: tags/t1
 
 conv-params: |
-  branches:
-    - trunk
-    - branches/*
-  rename-branches:
-    trunk: master
-    branches/*: "*"
-  tags:
-    - tags/*
-  rename-tags:
-    tags/*: "*"
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."trunk" = "master"
+  rename-branches."branches/*" = "*"
+
+  tags = ["tags/*"]
+  rename-tags."tags/*" = "*"
 
 git-tags:
   - tag: t1

--- a/convert-tests/tests/tags/crlf-meta.yaml
+++ b/convert-tests/tests/tags/crlf-meta.yaml
@@ -26,14 +26,11 @@ svn-revs:
         copy-from-path: trunk
 
 conv-params: |
-  branches:
-    - trunk
-  rename-branches:
-    trunk: master
-  tags:
-    - tags/*
-  rename-tags:
-    tags/*: "*"
+  branches = ["trunk"]
+  rename-branches."trunk" = "master"
+
+  tags = ["tags/*"]
+  rename-tags."tags/*" = "*"
 
 git-tags:
   - tag: t1

--- a/convert-tests/tests/tags/custom-meta.yaml
+++ b/convert-tests/tests/tags/custom-meta.yaml
@@ -35,23 +35,22 @@ svn-revs:
         copy-from-path: trunk
 
 conv-params: |
-  branches:
-    - trunk
-  rename-branches:
-    trunk: master
-  tags:
-    - tags/*
-  rename-tags:
-    tags/*: "*"
-  user-map-file: user-map.txt
-  user-fallback-template: "{{ svn_author }} <unknown>"
-  tag-msg-template: |
-    uuid: {{ svn_uuid }}
-    author: {{ svn_author }}{% if mapped_author_name %}
-    mapped_author_name: {{ mapped_author_name }}{% endif %}{% if mapped_author_email %}
-    mapped_author_email: {{ mapped_author_email }}{% endif %}
-    log: {{ svn_log }}
-    path: {{ svn_path }}
+  branches = ["trunk"]
+  rename-branches."trunk" = "master"
+
+  tags = ["tags/*"]
+  rename-tags."tags/*" = "*"
+
+  user-map-file = "user-map.txt"
+  user-fallback-template = "{{ svn_author }} <unknown>"
+  tag-msg-template = """
+  uuid: {{ svn_uuid }}
+  author: {{ svn_author }}{% if mapped_author_name %}
+  mapped_author_name: {{ mapped_author_name }}{% endif %}{% if mapped_author_email %}
+  mapped_author_email: {{ mapped_author_email }}{% endif %}
+  log: {{ svn_log }}
+  path: {{ svn_path }}
+  """
 
 user-map: |
   user1 = User 1 <user1@somewhere>

--- a/convert-tests/tests/tags/default-meta.yaml
+++ b/convert-tests/tests/tags/default-meta.yaml
@@ -35,14 +35,11 @@ svn-revs:
         copy-from-path: trunk
 
 conv-params: |
-  branches:
-    - trunk
-  rename-branches:
-    trunk: master
-  tags:
-    - tags/*
-  rename-tags:
-    tags/*: "*"
+  branches = ["trunk"]
+  rename-branches."trunk" = "master"
+
+  tags = ["tags/*"]
+  rename-tags."tags/*" = "*"
 
 git-tags:
   - tag: t1

--- a/convert-tests/tests/tags/from-branch-with-changes.yaml
+++ b/convert-tests/tests/tags/from-branch-with-changes.yaml
@@ -28,10 +28,8 @@ svn-revs:
         text: "y\n"
 
 conv-params: |
-  branches:
-    - trunk
-  tags:
-    - tags/*
+  branches = ["trunk"]
+  tags = ["tags/*"]
 
 git-revs:
   - rev: trunk~1

--- a/convert-tests/tests/tags/from-branch.yaml
+++ b/convert-tests/tests/tags/from-branch.yaml
@@ -24,14 +24,11 @@ svn-revs:
         copy-from-path: trunk
 
 conv-params: |
-  branches:
-    - trunk
-  rename-branches:
-    trunk: master
-  tags:
-    - tags/*
-  rename-tags:
-    tags/*: "*"
+  branches = ["trunk"]
+  rename-branches."trunk" = "master"
+
+  tags = ["tags/*"]
+  rename-tags."tags/*" = "*"
 
 git-tags:
   - tag: t1

--- a/convert-tests/tests/tags/from-empty.yaml
+++ b/convert-tests/tests/tags/from-empty.yaml
@@ -17,9 +17,8 @@ svn-revs:
         text: "x\n"
 
 conv-params: |
-  tags:
-    - tags/*
-  head: tags/t1
+  tags = ["tags/*"]
+  head = "tags/t1"
 
 git-revs:
   - rev: tags/t1~0

--- a/convert-tests/tests/tags/from-tag.yaml
+++ b/convert-tests/tests/tags/from-tag.yaml
@@ -31,15 +31,13 @@ svn-revs:
         copy-from-path: tags/t1
 
 conv-params: |
-  branches:
-    - trunk
-  rename-branches:
-    trunk: master
-  tags:
-    - tags/*
-  rename-tags:
-    tags/*: "*"
-  head: trunk
+  branches = ["trunk"]
+  rename-branches."trunk" = "master"
+
+  tags = ["tags/*"]
+  rename-tags."tags/*" = "*"
+
+  head = "trunk"
 
 git-tags:
   - tag: t1

--- a/convert-tests/tests/tags/modify.yaml
+++ b/convert-tests/tests/tags/modify.yaml
@@ -31,10 +31,8 @@ svn-revs:
         text: "y\n"
 
 conv-params: |
-  branches:
-    - trunk
-  tags:
-    - tags/*
+  branches = ["trunk"]
+  tags = ["tags/*"]
 
 git-revs:
   - rev: trunk~1

--- a/convert-tests/tests/text-delta/copy-modify-file.yaml
+++ b/convert-tests/tests/text-delta/copy-modify-file.yaml
@@ -35,8 +35,7 @@ svn-revs:
         ]
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~1

--- a/convert-tests/tests/text-delta/copy-replace-modify-file.yaml
+++ b/convert-tests/tests/text-delta/copy-replace-modify-file.yaml
@@ -41,8 +41,7 @@ svn-revs:
         ]
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~1

--- a/convert-tests/tests/text-delta/modify-file.yaml
+++ b/convert-tests/tests/text-delta/modify-file.yaml
@@ -34,8 +34,7 @@ svn-revs:
         ]
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~1

--- a/convert-tests/tests/text-delta/modify-symlink.yaml
+++ b/convert-tests/tests/text-delta/modify-symlink.yaml
@@ -38,8 +38,7 @@ svn-revs:
         ]
 
 conv-params: |
-  branches:
-    - trunk
+  branches = ["trunk"]
 
 git-revs:
   - rev: trunk~1

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,14 +66,14 @@ fn main_inner() -> Result<(), RunError> {
         return Err(RunError::Generic);
     }
 
-    let params_raw = match std::fs::read(&args.conv_params) {
+    let params_raw = match std::fs::read_to_string(&args.conv_params) {
         Ok(r) => r,
         Err(e) => {
             eprintln!("failed to read {:?}: {e}", args.conv_params);
             return Err(RunError::Generic);
         }
     };
-    let params: params_file::ConvParams = match serde_yaml::from_slice(&params_raw) {
+    let params: params_file::ConvParams = match toml::from_str(&params_raw) {
         Ok(r) => r,
         Err(e) => {
             eprintln!("failed to parse {:?}: {e}", args.conv_params);


### PR DESCRIPTION
Since this is a breaking change, version is bumped to 0.2.0.