### PR TITLE
feat: add support for partial branch creation handling

### DIFF
--- a/book/src/documentation/conv-params.md
+++ b/book/src/documentation/conv-params.md
@@ -56,6 +56,38 @@
   keep-deleted-tags = false
   ```
 
+* `partial-branches` and `partial-tags` (default: empty array)
+
+  Arrays that specify which branches or tags are allowed to be created as
+  partial branches/tags. Partial branches are created from subdirectories
+  (e.g., `<BRANCH_DIR>/subpath` instead of `<BRANCH_DIR>`). The converted Git
+  branches will contain the complete branch tree structure.
+
+  This is useful when SVN branches are created by copying only a subdirectory
+  of another branch instead of the entire branch.
+
+  <u>Example</u>
+
+  ```toml
+  branches = [
+    "branches/*",
+    "branches/more/*"
+  ]
+  partial-branches = [
+    # Allow branch "branches/some_branch" to be a partial branch
+    "branches/some_branch",
+    # Allow each branch in "branches/more" to be a partial branch
+    "branches/more/*",
+  ]
+
+  partial-tags = [
+    # Allow each tag in "tags" to be a partial tag
+    "tags/*",
+  ]
+  ```
+
+  **Note:** Merges from/to partial branches are not yet supported.
+
 * `head` (default: `trunk`)
 
   Specifies which branch will be used as Git HEAD. You have to specify the

--- a/convert-tests/tests/branches/create-partial-copy-parent.yaml
+++ b/convert-tests/tests/branches/create-partial-copy-parent.yaml
@@ -1,0 +1,103 @@
+svn-revs:
+  - props:
+      svn:log: init directories
+    nodes:
+      - path: trunk
+        kind: dir
+        action: add
+  - props:
+      svn:log: init trunk
+    nodes:
+      - path: trunk/x
+        kind: dir
+        action: add
+      - path: trunk/x/sub_x
+        kind: dir
+        action: add
+      - path: trunk/x/sub_x/A
+        kind: file
+        action: add
+        text: "file A\n"
+      - path: trunk/y
+        kind: dir
+        action: add
+      - path: trunk/y/B
+        kind: file
+        action: add
+        text: "file B\n"
+  - props:
+      svn:log: copy trunk to branches
+    nodes:
+      - path: branches
+        kind: dir
+        action: add
+        copy-from-path: trunk
+
+conv-params: |
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."trunk" = "master"
+  rename-branches."branches/*" = "*"
+
+  partial-branches = [
+    "branches/*",
+  ]
+
+logs: |
+  D svn2git::convert::stage1: importing SVN revision 3
+  W svn2git::convert::stage1: copying branch "trunk" to non-branch "branches"
+  D svn2git::convert::stage1: committed on unbranched branch
+  D svn2git::convert::stage1: creating partial branch/tag "branches/x" from "trunk" with sub-path "x"
+  D svn2git::convert::stage1: creating partial branch/tag "branches/y" from "trunk" with sub-path "y"
+
+git-revs:
+  - rev: master~1
+    parents: []
+    tree: {}
+  - rev: master~0
+    parents: [master~1]
+    tree:
+      x:
+        type: dir
+      x/sub_x:
+        type: dir
+      x/sub_x/A:
+        type: normal
+        data: "file A\n"
+      y:
+        type: dir
+      y/B:
+        type: normal
+        data: "file B\n"
+  - rev: x~0
+    parents: [master~0]
+    tree:
+      x:
+        type: dir
+      x/sub_x:
+        type: dir
+      x/sub_x/A:
+        type: normal
+        data: "file A\n"
+      y:
+        type: dir
+      y/B:
+        type: normal
+        data: "file B\n"
+  - rev: y~0
+    parents: [master~0]
+    tree:
+      x:
+        type: dir
+      x/sub_x:
+        type: dir
+      x/sub_x/A:
+        type: normal
+        data: "file A\n"
+      y:
+        type: dir
+      y/B:
+        type: normal
+        data: "file B\n"

--- a/convert-tests/tests/branches/create-partial.yaml
+++ b/convert-tests/tests/branches/create-partial.yaml
@@ -1,0 +1,136 @@
+svn-revs:
+  - props:
+      svn:log: init directories
+    nodes:
+      - path: trunk
+        kind: dir
+        action: add
+      - path: branches
+        kind: dir
+        action: add
+  - props:
+      svn:log: init trunk
+    nodes:
+      - path: trunk/x
+        kind: dir
+        action: add
+      - path: trunk/x/sub_x
+        kind: dir
+        action: add
+      - path: trunk/x/sub_x/A
+        kind: file
+        action: add
+        text: "file A\n"
+      - path: trunk/y
+        kind: dir
+        action: add
+      - path: trunk/y/B
+        kind: file
+        action: add
+        text: "file B\n"
+  - props:
+      svn:log: copy trunk/x to branches/b1
+    nodes:
+      - path: branches/b1
+        kind: dir
+        action: add
+        copy-from-path: trunk/x
+  - props:
+      svn:log: modify A
+    nodes:
+      - path: branches/b1/sub_x/A
+        kind: file
+        action: change
+        text: "modified A\n"
+  - props:
+      svn:log: copy branches/b1/sub_x to branches/b2
+    nodes:
+      - path: branches/b2
+        kind: dir
+        action: add
+        copy-from-path: branches/b1/sub_x
+
+conv-params: |
+  branches = [
+    "trunk",
+    "branches/*",
+  ]
+  rename-branches."trunk" = "master"
+  rename-branches."branches/*" = "*"
+
+  partial-branches = [
+    "branches/*",
+  ]
+
+logs: |
+  D svn2git::convert::stage1: importing SVN revision 3
+  D svn2git::convert::stage1: creating partial branch/tag "branches/b1" from "trunk" with sub-path "x"
+  D svn2git::convert::stage1: importing SVN revision 4
+  D svn2git::convert::stage1: modification on branch/tag "branches/b1"
+  D svn2git::convert::stage1: importing SVN revision 5
+  D svn2git::convert::stage1: creating partial branch/tag "branches/b2" from "branches/b1" with sub-path "x/sub_x"
+
+git-revs:
+  - rev: master~1
+    parents: []
+    tree: {}
+  - rev: master~0
+    parents: [master~1]
+    tree:
+      x:
+        type: dir
+      x/sub_x:
+        type: dir
+      x/sub_x/A:
+        type: normal
+        data: "file A\n"
+      y:
+        type: dir
+      y/B:
+        type: normal
+        data: "file B\n"
+  - rev: b1~1
+    parents: [master~0]
+    tree:
+      x:
+        type: dir
+      x/sub_x:
+        type: dir
+      x/sub_x/A:
+        type: normal
+        data: "file A\n"
+      y:
+        type: dir
+      y/B:
+        type: normal
+        data: "file B\n"
+  - rev: b1~0
+    parents: [b1~1]
+    tree:
+      x:
+        type: dir
+      x/sub_x:
+        type: dir
+      x/sub_x/A:
+        type: normal
+        data: "modified A\n"
+      y:
+        type: dir
+      y/B:
+        type: normal
+        data: "file B\n"
+  - rev: b2~0
+    parents: [b1~0]
+    tree:
+      x:
+        type: dir
+      x/sub_x:
+        type: dir
+      x/sub_x/A:
+        type: normal
+        data: "modified A\n"
+      y:
+        type: dir
+      y/B:
+        type: normal
+        data: "file B\n"

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,6 +159,19 @@ fn main_inner() -> Result<(), RunError> {
             })?;
     }
 
+    for name in params.partial_branches.iter() {
+        options.add_partial_branch(name.as_bytes()).map_err(|_| {
+            tracing::error!("invalid partial branch name: {name:?}");
+            RunError::Generic
+        })?;
+    }
+    for name in params.partial_tags.iter() {
+        options.add_partial_tag(name.as_bytes()).map_err(|_| {
+            tracing::error!("invalid partial tag name: {name:?}");
+            RunError::Generic
+        })?;
+    }
+
     for ignored_merge in params.ignore_merges.iter() {
         options.add_ignored_merge_at(ignored_merge.path.as_bytes(), ignored_merge.rev);
     }

--- a/src/params_file.rs
+++ b/src/params_file.rs
@@ -10,12 +10,16 @@ pub(crate) struct ConvParams {
     pub(crate) rename_branches: HashMap<String, String>,
     #[serde(rename = "keep-deleted-branches", default = "true_")]
     pub(crate) keep_deleted_branches: bool,
+    #[serde(rename = "partial-branches", default)]
+    pub(crate) partial_branches: Vec<String>,
     #[serde(default)]
     pub(crate) tags: Vec<String>,
     #[serde(rename = "rename-tags", default)]
     pub(crate) rename_tags: HashMap<String, String>,
     #[serde(rename = "keep-deleted-tags", default = "true_")]
     pub(crate) keep_deleted_tags: bool,
+    #[serde(rename = "partial-tags", default)]
+    pub(crate) partial_tags: Vec<String>,
     #[serde(default = "default_head")]
     pub(crate) head: String,
     #[serde(rename = "unbranched-name")]


### PR DESCRIPTION
Partial branches are created from subdirectories (e.g., <BRANCH_DIR>/subpath instead of <BRANCH_DIR>). The converted Git branches will contain the complete branch tree structure.

Merges from/to partial branches are not yet supported.