### PR TITLE
Git svn mode

### DIFF
--- a/src/convert/git_wrap.rs
+++ b/src/convert/git_wrap.rs
@@ -1,6 +1,6 @@
 use super::ConvertError;
+use crate::convert::Options;
 use crate::git;
-
 pub(super) struct Importer {
     importer: git::Importer,
 }
@@ -9,8 +9,9 @@ impl Importer {
     pub(super) fn init(
         path: &std::path::Path,
         obj_cache_size: usize,
+        options: &Options,
     ) -> Result<Self, ConvertError> {
-        let importer = git::Importer::init(path, obj_cache_size).map_err(|e| {
+        let importer = git::Importer::init(path, obj_cache_size, options).map_err(|e| {
             tracing::error!("failed to initialize git import: {e}");
             ConvertError
         })?;

--- a/src/convert/mod.rs
+++ b/src/convert/mod.rs
@@ -29,6 +29,7 @@ pub(crate) trait GitMetaMaker {
     fn make_git_commit_meta(
         &self,
         svn_uuid: Option<&uuid::Uuid>,
+        svn_url: String,
         svn_rev_no: u32,
         svn_path: Option<&[u8]>,
         svn_rev_props: &FHashMap<Vec<u8>, Vec<u8>>,
@@ -37,6 +38,7 @@ pub(crate) trait GitMetaMaker {
     fn make_git_tag_meta(
         &self,
         svn_uuid: Option<&uuid::Uuid>,
+        svn_url: String,
         svn_rev_no: u32,
         svn_path: &[u8],
         svn_rev_props: &FHashMap<Vec<u8>, Vec<u8>>,
@@ -53,12 +55,7 @@ pub(crate) fn convert(
 ) -> Result<(), ConvertError> {
     let mut options_ok = true;
 
-    if options.git_svn_mode {
-        if options.git_svn_url.is_none() {
-            tracing::error!("git-svn mode requires a repository URL");
-            options_ok = false;
-        }
-
+    if options.git_svn.is_some() {
         if options.generate_gitignore {
             tracing::error!("git-svn mode does not support generating .gitignore");
             options_ok = false;

--- a/src/convert/mod.rs
+++ b/src/convert/mod.rs
@@ -29,6 +29,7 @@ pub(crate) trait GitMetaMaker {
     fn make_git_commit_meta(
         &self,
         svn_uuid: Option<&uuid::Uuid>,
+        svn_url: String,
         svn_rev_no: u32,
         svn_path: Option<&[u8]>,
         svn_rev_props: &FHashMap<Vec<u8>, Vec<u8>>,
@@ -37,6 +38,7 @@ pub(crate) trait GitMetaMaker {
     fn make_git_tag_meta(
         &self,
         svn_uuid: Option<&uuid::Uuid>,
+        svn_url: String,
         svn_rev_no: u32,
         svn_path: &[u8],
         svn_rev_props: &FHashMap<Vec<u8>, Vec<u8>>,
@@ -51,6 +53,24 @@ pub(crate) fn convert(
     src_is_remote: bool,
     dst_path: &std::path::Path,
 ) -> Result<(), ConvertError> {
+    let mut options_ok = true;
+
+    if options.git_svn.is_some() {
+        if options.generate_gitignore {
+            tracing::error!("git-svn mode does not support generating .gitignore");
+            options_ok = false;
+        }
+
+        if !options.delete_files.is_empty() {
+            tracing::error!("git-svn mode does not support deleting files");
+            options_ok = false;
+        }
+    }
+
+    if !options_ok {
+        return Err(ConvertError);
+    }
+
     progress_print.set_progress("initializing git import".into());
 
     let mut git_import = git_wrap::Importer::init(dst_path, options.git_obj_cache_size)?;

--- a/src/convert/mod.rs
+++ b/src/convert/mod.rs
@@ -73,7 +73,7 @@ pub(crate) fn convert(
 
     progress_print.set_progress("initializing git import".into());
 
-    let mut git_import = git_wrap::Importer::init(dst_path, options.git_obj_cache_size)?;
+    let mut git_import = git_wrap::Importer::init(dst_path, options.git_obj_cache_size, options)?;
 
     let mut run_stages = || {
         let stage1_out = stage1::run(

--- a/src/convert/options.rs
+++ b/src/convert/options.rs
@@ -1,10 +1,12 @@
 use std::borrow::Cow;
 
 use super::ConvertError;
+use crate::params_file::GitSvnParams;
 use crate::path_pattern::PathPattern;
 use crate::{FHashMap, FHashSet};
 
 pub(crate) struct InitOptions {
+    pub(crate) git_svn: Option<GitSvnParams>,
     pub(crate) keep_deleted_branches: bool,
     pub(crate) keep_deleted_tags: bool,
     pub(crate) head_path: Vec<u8>,
@@ -21,6 +23,7 @@ pub(crate) struct InitOptions {
 pub(crate) struct Options {
     root_dir_spec: ContainerDirSpecNode,
     pub(super) rename_branches: BranchRenamer,
+    pub(crate) git_svn: Option<GitSvnParams>,
     pub(super) keep_deleted_branches: bool,
     pub(super) partial_branches: PartialBranchSet,
     pub(super) rename_tags: BranchRenamer,
@@ -67,6 +70,7 @@ impl Options {
                 subdirs: FHashMap::default(),
             },
             rename_branches: BranchRenamer::new(),
+            git_svn: init.git_svn,
             keep_deleted_branches: init.keep_deleted_branches,
             partial_branches: PartialBranchSet::new(),
             rename_tags: BranchRenamer::new(),
@@ -364,6 +368,7 @@ mod tests {
 
     fn default_init() -> InitOptions {
         InitOptions {
+            git_svn: None,
             keep_deleted_branches: true,
             keep_deleted_tags: true,
             head_path: b"trunk".to_vec(),

--- a/src/convert/options.rs
+++ b/src/convert/options.rs
@@ -1,12 +1,12 @@
 use std::borrow::Cow;
 
 use super::ConvertError;
+use crate::params_file::GitSvnParams;
 use crate::path_pattern::PathPattern;
 use crate::{FHashMap, FHashSet};
 
 pub(crate) struct InitOptions {
-    pub(crate) git_svn_mode: bool,
-    pub(crate) git_svn_url: Option<String>,
+    pub(crate) git_svn: Option<GitSvnParams>,
     pub(crate) keep_deleted_branches: bool,
     pub(crate) keep_deleted_tags: bool,
     pub(crate) head_path: Vec<u8>,
@@ -21,8 +21,7 @@ pub(crate) struct InitOptions {
 }
 
 pub(crate) struct Options {
-    pub(super) git_svn_mode: bool,
-    pub(super) git_svn_url: Option<String>,
+    pub(super) git_svn: Option<GitSvnParams>,
     root_dir_spec: ContainerDirSpecNode,
     pub(super) rename_branches: BranchRenamer,
     pub(super) keep_deleted_branches: bool,
@@ -66,8 +65,7 @@ pub(crate) struct PartialBranchAddError;
 impl Options {
     pub(crate) fn new(init: InitOptions) -> Self {
         Self {
-            git_svn_mode: init.git_svn_mode,
-            git_svn_url: init.git_svn_url,
+            git_svn: init.git_svn,
             root_dir_spec: ContainerDirSpecNode {
                 wildcard: None,
                 subdirs: FHashMap::default(),
@@ -370,8 +368,7 @@ mod tests {
 
     fn default_init() -> InitOptions {
         InitOptions {
-            git_svn_mode: false,
-            git_svn_url: None,
+            git_svn: None,
             keep_deleted_branches: true,
             keep_deleted_tags: true,
             head_path: b"trunk".to_vec(),

--- a/src/convert/options.rs
+++ b/src/convert/options.rs
@@ -1,4 +1,7 @@
 use std::borrow::Cow;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{self, Write};
 
 use super::ConvertError;
 use crate::params_file::GitSvnParams;
@@ -29,7 +32,7 @@ pub(crate) struct Options {
     pub(super) rename_tags: BranchRenamer,
     pub(super) keep_deleted_tags: bool,
     pub(super) partial_tags: PartialBranchSet,
-    pub(super) head_path: Vec<u8>,
+    pub(crate) head_path: Vec<u8>,
     pub(super) unbranched_name: Option<String>,
     pub(super) enable_merges: bool,
     pub(super) merge_optional: PathPattern,
@@ -58,6 +61,7 @@ pub(super) enum DirClass<'a> {
     BranchParent,
 }
 
+#[derive(Debug)]
 pub(crate) struct BranchRenameAddError;
 
 pub(crate) struct PartialBranchAddError;
@@ -264,6 +268,168 @@ impl Options {
             .or_default()
             .insert(path.to_vec());
     }
+
+    fn git_svn_mapping<'a>(&'a self, remote_name: &'a str) -> Vec<String> {
+        struct State<'o, 'r> {
+            options: &'o Options,
+            remote_name: &'o str,
+            result: &'r mut Vec<String>,
+            current: Vec<String>,
+        }
+        impl<'o, 'r> State<'o, 'r> {
+            fn new(
+                options: &'o Options,
+                remote_name: &'o str,
+                result: &'r mut Vec<String>,
+            ) -> Self {
+                Self {
+                    options,
+                    remote_name,
+                    result,
+                    current: Vec::new(),
+                }
+            }
+            fn fill(&mut self) {
+                self.traverse_container(&self.options.root_dir_spec, false);
+                for (from_bytes, to_bytes) in &self.options.rename_branches.exact {
+                    if let Ok(from) = String::from_utf8(from_bytes.clone()) {
+                        if let Ok(to) = String::from_utf8(to_bytes.clone()) {
+                            let remote = self.remote_name;
+                            self.result
+                                .push(format!("branches = {from}:refs/remotes/{remote}/{to}"));
+                        }
+                    }
+                }
+
+                for (from_bytes, to_bytes) in &self.options.rename_tags.exact {
+                    if let Ok(from) = String::from_utf8(from_bytes.clone()) {
+                        if let Ok(to) = String::from_utf8(to_bytes.clone()) {
+                            let remote = self.remote_name;
+                            self.result
+                                .push(format!("tags = {from}:refs/remotes/{remote}/tags/{to}"));
+                        }
+                    }
+                }
+            }
+            fn traverse_node_tags(&mut self, node: &DirSpecNode, is_tag: bool) {
+                match node {
+                    DirSpecNode::Branch(tag) => self.push(*tag, ""),
+                    DirSpecNode::Container(container) => self.traverse_container(container, is_tag),
+                }
+            }
+            fn traverse_container(&mut self, container: &ContainerDirSpecNode, mut is_tag: bool) {
+                if let Some(tag) = container.wildcard {
+                    self.push(tag, "/*");
+                    is_tag = tag;
+                }
+                for (name_bytes, subnode) in &container.subdirs {
+                    if let Ok(name) = String::from_utf8(name_bytes.clone()) {
+                        self.current.push(name);
+                        self.traverse_node_tags(subnode, is_tag);
+                        self.current.pop();
+                    }
+                }
+            }
+            fn push(&mut self, tag: bool, suffix: &str) {
+                let remote = self.remote_name;
+                let path = self.current.join("/");
+
+                let renamer = if tag {
+                    &self.options.rename_tags
+                } else {
+                    &self.options.rename_branches
+                };
+                let suffixed = format!("{path}{suffix}");
+                let mut git_name = suffixed.clone();
+
+                for (from_prefix, to_prefix) in &renamer.prefix {
+                    if suffixed.as_bytes().starts_with(from_prefix) {
+                        let mut result_bytes = to_prefix.clone();
+                        result_bytes.extend_from_slice(&suffixed.as_bytes()[from_prefix.len()..]);
+                        git_name = String::from_utf8(result_bytes).unwrap_or(path.clone());
+                        break;
+                    }
+                }
+
+                if let Some(to) = renamer.exact.get(path.as_bytes()) {
+                    git_name = String::from_utf8(to.clone()).unwrap_or(path.clone());
+                }
+
+                if tag {
+                    self.result.push(format!(
+                        "tags = {suffixed}:refs/remotes/{remote}/tags/{git_name}"
+                    ));
+                } else {
+                    self.result.push(format!(
+                        "branches = {suffixed}:refs/remotes/{remote}/{git_name}"
+                    ));
+                }
+            }
+        }
+
+        let mut result = Vec::new();
+        let mut state = State::new(self, remote_name, &mut result);
+        state.fill();
+
+        let mut mapping: HashMap<String, (String, bool)> = HashMap::new();
+
+        for line in result {
+            if let Some(rest) = line.strip_prefix("branches = ") {
+                let colon_pos = rest.find(':').unwrap();
+                let path = rest[..colon_pos].to_string();
+                let git_name = rest[colon_pos + 1..]
+                    .strip_prefix("refs/remotes/origin/")
+                    .unwrap_or(&rest[colon_pos + 1..])
+                    .to_string();
+                mapping.insert(path, (git_name, false));
+            } else if let Some(rest) = line.strip_prefix("tags = ") {
+                let colon_pos = rest.find(':').unwrap();
+                let path = rest[..colon_pos].to_string();
+                let git_name = rest[colon_pos + 1..]
+                    .strip_prefix("refs/remotes/origin/tags/")
+                    .unwrap_or(&rest[colon_pos + 1..])
+                    .to_string();
+                mapping.insert(path, (git_name, true));
+            }
+        }
+
+        let mut final_result: Vec<String> = mapping
+            .into_iter()
+            .map(|(path, (git_name, is_tag))| {
+                if is_tag {
+                    format!("tags = {path}:refs/remotes/origin/tags/{git_name}")
+                } else {
+                    format!("branches = {path}:refs/remotes/origin/{git_name}",)
+                }
+            })
+            .collect();
+
+        final_result.sort();
+        final_result
+    }
+
+    pub(crate) fn write_git_svn_config(&self, file: &mut File) -> io::Result<()> {
+        if let Some(svn_params) = &self.git_svn {
+            let mut fetch = Vec::new();
+            fetch.write_all(&self.head_path)?;
+            fetch.write_all(b":refs/remotes/")?;
+            fetch.write_all(svn_params.remote_name.as_bytes())?;
+            fetch.write_all(b"/")?;
+            fetch.write_all(&self.rename_branches.rename(&self.head_path))?;
+
+            file.write_all(b"[svn-remote \"svn\"]\n\turl = ")?;
+            file.write_all(svn_params.url.as_bytes())?;
+            file.write_all(b"\n\tfetch = ")?;
+            file.write_all(&fetch)?;
+            for rule in &self.git_svn_mapping(&svn_params.remote_name) {
+                if rule.as_bytes() != fetch {
+                    file.write_all(b"\n\t")?;
+                    file.write_all(rule.as_bytes())?;
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 pub(super) struct BranchRenamer {
@@ -461,5 +627,111 @@ mod tests {
         );
         assert_eq!(options.classify_dir(b"b/c/b"), DirClass::Unbranched);
         assert_eq!(options.classify_dir(b"c"), DirClass::Unbranched);
+    }
+
+    #[test]
+    fn test_branches_mapping_simple() {
+        // branches = a    :refs/remotes/origin/a
+        // branches = b/*  :refs/remotes/origin/b/*
+        // branches = b/a/*:refs/remotes/origin/b/a/*
+        // branches = b/b  :refs/remotes/origin/b/b
+        // branches = b/c/a:refs/remotes/origin/b/c/a
+        // tags = ta    :refs/remotes/origin/ta
+        // tags = tb/*  :refs/remotes/origin/tb/*
+        // tags = tb/a/*:refs/remotes/origin/tb/a/*
+        // tags = tb/b  :refs/remotes/origin/tb/b
+        // tags = tb/c/a:refs/remotes/origin/tb/c/a
+        let mut options = Options::new(default_init());
+        options.add_branch_dir(b"a", false).unwrap();
+        options.add_branch_dir(b"b/*", false).unwrap();
+        options.add_branch_dir(b"b/a/*", false).unwrap();
+        options.add_branch_dir(b"b/b", false).unwrap();
+        options.add_branch_dir(b"b/c/a", false).unwrap();
+        options.add_branch_dir(b"d-*", false).unwrap();
+
+        options.add_branch_dir(b"ta", true).unwrap();
+        options.add_branch_dir(b"tb/*", true).unwrap();
+        options.add_branch_dir(b"tb/a/*", true).unwrap();
+        options.add_branch_dir(b"tb/b", true).unwrap();
+        options.add_branch_dir(b"tb/c/a", true).unwrap();
+        options.add_branch_dir(b"td-*", true).unwrap();
+
+        assert_eq!(
+            options.git_svn_mapping("origin"),
+            &[
+                "branches = a:refs/remotes/origin/a",
+                "branches = b/*:refs/remotes/origin/b/*",
+                "branches = b/a/*:refs/remotes/origin/b/a/*",
+                "branches = b/b:refs/remotes/origin/b/b",
+                "branches = b/c/a:refs/remotes/origin/b/c/a",
+                "branches = d-*:refs/remotes/origin/d-*",
+                "tags = ta:refs/remotes/origin/tags/ta",
+                "tags = tb/*:refs/remotes/origin/tags/tb/*",
+                "tags = tb/a/*:refs/remotes/origin/tags/tb/a/*",
+                "tags = tb/b:refs/remotes/origin/tags/tb/b",
+                "tags = tb/c/a:refs/remotes/origin/tags/tb/c/a",
+                "tags = td-*:refs/remotes/origin/tags/td-*",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_branches_mapping_with_rename() {
+        // branches = a    :refs/remotes/origin/a
+        // branches = b/*  :refs/remotes/origin/b/*
+        // branches = b/a/*:refs/remotes/origin/b/a/*
+        // branches = b/b  :refs/remotes/origin/b/b
+        // branches = b/c/a:refs/remotes/origin/b/c/a
+        // tags = ta    :refs/remotes/origin/ta
+        // tags = tb/*  :refs/remotes/origin/tb/*
+        // tags = tb/a/*:refs/remotes/origin/tb/a/*
+        // tags = tb/b  :refs/remotes/origin/tb/b
+        // tags = tb/c/a:refs/remotes/origin/tb/c/a
+        let mut options = Options::new(default_init());
+        options.add_branch_dir(b"a", false).unwrap();
+        options.add_branch_dir(b"b/*", false).unwrap();
+        options.add_branch_dir(b"b/a/*", false).unwrap();
+        options.add_branch_dir(b"b/b", false).unwrap();
+        options.add_branch_dir(b"b/c/a", false).unwrap();
+        options.add_branch_dir(b"d-*", false).unwrap();
+
+        options.add_branch_dir(b"ta", true).unwrap();
+        options.add_branch_dir(b"tb/*", true).unwrap();
+        options.add_branch_dir(b"tb/a/*", true).unwrap();
+        options.add_branch_dir(b"tb/b", true).unwrap();
+        options.add_branch_dir(b"tb/c/a", true).unwrap();
+        options.add_branch_dir(b"td-*", true).unwrap();
+
+        options.add_branch_rename(b"exact", b"exact2").unwrap();
+        options.add_branch_rename(b"b/exact", b"exact3").unwrap();
+        options.add_branch_rename(b"b/a/*", b"exact/*").unwrap();
+        options.add_branch_rename(b"d-*", b"exact-*").unwrap();
+
+        options.add_tag_rename(b"texact", b"texact2").unwrap();
+        options.add_tag_rename(b"tb/exact", b"texact3").unwrap();
+        options.add_tag_rename(b"tb/a/*", b"texact/*").unwrap();
+        options.add_tag_rename(b"td-*", b"texact-*").unwrap();
+
+        assert_eq!(
+            options.git_svn_mapping("origin"),
+            &[
+                "branches = a:refs/remotes/origin/a",
+                "branches = b/*:refs/remotes/origin/b/*",
+                "branches = b/a/*:refs/remotes/origin/exact/*",
+                "branches = b/b:refs/remotes/origin/b/b",
+                "branches = b/c/a:refs/remotes/origin/b/c/a",
+                "branches = b/exact:refs/remotes/origin/exact3",
+                "branches = d-*:refs/remotes/origin/exact-*",
+                "branches = exact:refs/remotes/origin/exact2",
+                "tags = ta:refs/remotes/origin/tags/ta",
+                "tags = tb/*:refs/remotes/origin/tags/tb/*",
+                "tags = tb/a/*:refs/remotes/origin/tags/texact/*",
+                "tags = tb/b:refs/remotes/origin/tags/tb/b",
+                "tags = tb/c/a:refs/remotes/origin/tags/tb/c/a",
+                "tags = tb/exact:refs/remotes/origin/tags/texact3",
+                "tags = td-*:refs/remotes/origin/tags/texact-*",
+                "tags = texact:refs/remotes/origin/tags/texact2",
+            ]
+        );
     }
 }

--- a/src/convert/stage2.rs
+++ b/src/convert/stage2.rs
@@ -450,7 +450,9 @@ impl Stage<'_> {
         git_message.extend(b"git-svn-id: ");
         git_message.extend(self.options.git_svn_url.as_deref().unwrap().as_bytes());
         if !branch_path.is_empty() {
+            if !git_message.ends_with(b"/") {
             git_message.push(b'/');
+            }
             git_message.extend(branch_path);
         }
         git_message.push(b'@');

--- a/src/convert/stage2.rs
+++ b/src/convert/stage2.rs
@@ -278,6 +278,10 @@ impl Stage<'_> {
             .metadata_maker
             .make_git_commit_meta(
                 self.stage1_out.svn_uuid.as_ref(),
+                self.options
+                    .git_svn
+                    .as_ref()
+                    .map_or(String::new(), |p| p.url.clone()),
                 self.stage1_out.root_rev_data[root_commit].svn_rev,
                 None,
                 &self.stage1_out.root_rev_data[root_commit].svn_rev_props,
@@ -371,6 +375,10 @@ impl Stage<'_> {
             .metadata_maker
             .make_git_commit_meta(
                 self.stage1_out.svn_uuid.as_ref(),
+                self.options
+                    .git_svn
+                    .as_ref()
+                    .map_or(String::new(), |p| p.url.clone()),
                 self.stage1_out.root_rev_data[root_commit].svn_rev,
                 Some(branch_path),
                 &self.stage1_out.root_rev_data[root_commit].svn_rev_props,
@@ -429,6 +437,10 @@ impl Stage<'_> {
             .metadata_maker
             .make_git_tag_meta(
                 self.stage1_out.svn_uuid.as_ref(),
+                self.options
+                    .git_svn
+                    .as_ref()
+                    .map_or(String::new(), |p| p.url.clone()),
                 self.stage1_out.root_rev_data[root_commit].svn_rev,
                 branch_path,
                 &self.stage1_out.root_rev_data[root_commit].svn_rev_props,

--- a/src/convert/stage2.rs
+++ b/src/convert/stage2.rs
@@ -279,6 +279,10 @@ impl Stage<'_> {
             .metadata_maker
             .make_git_commit_meta(
                 self.stage1_out.svn_uuid.as_ref(),
+                self.options
+                    .git_svn
+                    .as_ref()
+                    .map_or(String::new(), |p| p.url.clone()),
                 self.stage1_out.root_rev_data[root_commit].svn_rev,
                 None,
                 &self.stage1_out.root_rev_data[root_commit].svn_rev_props,
@@ -292,7 +296,7 @@ impl Stage<'_> {
         parents.extend(self.last_unbranched_commit);
 
         let mut git_message = gix_object::bstr::BString::from(git_commit_meta.message);
-        if self.options.git_svn_mode {
+        if self.options.git_svn.is_some() {
             self.add_git_svn_metadata(
                 &mut git_message,
                 b"",
@@ -381,6 +385,10 @@ impl Stage<'_> {
             .metadata_maker
             .make_git_commit_meta(
                 self.stage1_out.svn_uuid.as_ref(),
+                self.options
+                    .git_svn
+                    .as_ref()
+                    .map_or(String::new(), |p| p.url.clone()),
                 self.stage1_out.root_rev_data[root_commit].svn_rev,
                 Some(branch_path),
                 &self.stage1_out.root_rev_data[root_commit].svn_rev_props,
@@ -395,7 +403,7 @@ impl Stage<'_> {
         parents.extend(git_merges);
 
         let mut git_message = gix_object::bstr::BString::from(git_commit_meta.message);
-        if self.options.git_svn_mode {
+        if self.options.git_svn.is_some() {
             self.add_git_svn_metadata(
                 &mut git_message,
                 branch_path,
@@ -448,7 +456,7 @@ impl Stage<'_> {
             git_message.push(b'\n');
         }
         git_message.extend(b"git-svn-id: ");
-        git_message.extend(self.options.git_svn_url.as_deref().unwrap().as_bytes());
+        git_message.extend(self.options.git_svn.as_ref().unwrap().url.as_bytes());
         if !branch_path.is_empty() {
             if !git_message.ends_with(b"/") {
             git_message.push(b'/');
@@ -476,6 +484,10 @@ impl Stage<'_> {
             .metadata_maker
             .make_git_tag_meta(
                 self.stage1_out.svn_uuid.as_ref(),
+                self.options
+                    .git_svn
+                    .as_ref()
+                    .map_or(String::new(), |p| p.url.clone()),
                 self.stage1_out.root_rev_data[root_commit].svn_rev,
                 branch_path,
                 &self.stage1_out.root_rev_data[root_commit].svn_rev_props,

--- a/src/git/import/mod.rs
+++ b/src/git/import/mod.rs
@@ -5,6 +5,7 @@ use gix_hash::ObjectId;
 use gix_object::ObjectRef;
 use gix_object::tree::EntryKind;
 
+use crate::convert::Options;
 use crate::{FHashMap, FHashSet};
 
 mod change_set;
@@ -125,8 +126,12 @@ pub(crate) struct Importer {
 }
 
 impl Importer {
-    pub(crate) fn init(path: &std::path::Path, obj_cache_size: usize) -> Result<Self, ImportError> {
-        init_repo(path)?;
+    pub(crate) fn init(
+        path: &std::path::Path,
+        obj_cache_size: usize,
+        options: &Options,
+    ) -> Result<Self, ImportError> {
+        init_repo(path, options)?;
 
         let hash_kind = gix_hash::Kind::Sha1;
 
@@ -311,7 +316,7 @@ pub(crate) enum ImportFinishProgress {
     MakeIndex,
 }
 
-fn init_repo(path: &std::path::Path) -> Result<(), ImportError> {
+fn init_repo(path: &std::path::Path, options: &Options) -> Result<(), ImportError> {
     std::fs::create_dir(path).map_err(|e| ImportError::CreateDirError {
         path: path.to_path_buf(),
         error: e,
@@ -349,7 +354,20 @@ fn init_repo(path: &std::path::Path) -> Result<(), ImportError> {
 
     let config_path = path.join("config");
     let config = b"[core]\n\trepositoryformatversion = 0\n\tfilemode = true\n\tbare = true\n";
-    create_file(config_path, config)?;
+    std::fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&config_path)
+        .and_then(|mut file| {
+            file.write_all(config)?;
+            file.flush()?;
+            options.write_git_svn_config(&mut file)?;
+            Ok(())
+        })
+        .map_err(|e| ImportError::CreateFileError {
+            path: config_path,
+            error: e,
+        })?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,8 +95,7 @@ fn main_inner() -> Result<(), RunError> {
             })?;
 
     let mut options = convert::Options::new(convert::InitOptions {
-        git_svn_mode: params.git_svn_mode,
-        git_svn_url: params.git_svn_url,
+        git_svn: params.git_svn,
         keep_deleted_branches: params.keep_deleted_branches,
         keep_deleted_tags: params.keep_deleted_tags,
         head_path: params.head.into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,7 @@ fn main_inner() -> Result<(), RunError> {
             })?;
 
     let mut options = convert::Options::new(convert::InitOptions {
+        git_svn: params.git_svn,
         keep_deleted_branches: params.keep_deleted_branches,
         keep_deleted_tags: params.keep_deleted_tags,
         head_path: params.head.into(),
@@ -204,24 +205,42 @@ fn main_inner() -> Result<(), RunError> {
     let user_fallback_template = params.user_fallback_template.as_deref().unwrap_or(
         r#"{{ svn_author or "no-author" }} <{{ svn_author or "no-author" }}{% if svn_uuid %}@{{ svn_uuid }}{% endif %}>"#,
     );
-    let commit_msg_template = params
-        .commit_msg_template
-        .as_deref()
-        .unwrap_or(indoc::indoc! {r#"
+    let commit_msg_template = if options.git_svn.is_some() {
+        indoc::indoc! {r#"
+            {% if svn_log %}{{ svn_log }}
+
+            {% endif %}git-svn-id: {{ svn_url }}{{ svn_path }}@{{ svn_rev }} {{ svn_uuid }}
+        "#}
+    } else {
+        indoc::indoc! {r#"
             {% if svn_log %}{{ svn_log }}
 
             {% endif %}[[SVN revision: {{ svn_rev }}]]{% if svn_path %}
             [[SVN path: {{ svn_path }}]]{% endif %}
-        "#});
+        "#}
+    };
+    let tag_msg_template = if options.git_svn.is_some() {
+        indoc::indoc! {r#"
+            {% if svn_log %}{{ svn_log }}
+
+            {% endif %}git-svn-id: {{ svn_url }}{{ svn_path }}@{{ svn_rev }} {{ svn_uuid }}
+        "#}
+    } else {
+        indoc::indoc! {r#"
+            {% if svn_log %}{{ svn_log }}
+
+            {% endif %}[[SVN revision: {{ svn_rev }}]]
+            [[SVN path: {{ svn_path }}]]
+       "#}
+    };
+    let commit_msg_template = params
+        .commit_msg_template
+        .as_deref()
+        .unwrap_or(commit_msg_template);
     let tag_msg_template = params
         .tag_msg_template
         .as_deref()
-        .unwrap_or(indoc::indoc! {r#"
-           {% if svn_log %}{{ svn_log }}
-
-           {% endif %}[[SVN revision: {{ svn_rev }}]]
-           [[SVN path: {{ svn_path }}]]
-        "#});
+        .unwrap_or(tag_msg_template);
 
     let metadata_maker = make_meta::GitMetadataMaker::new(
         &user_map,

--- a/src/make_meta.rs
+++ b/src/make_meta.rs
@@ -38,11 +38,19 @@ impl crate::convert::GitMetaMaker for GitMetadataMaker<'_> {
     fn make_git_commit_meta(
         &self,
         svn_uuid: Option<&uuid::Uuid>,
+        svn_url: String,
         svn_rev_no: u32,
         svn_path: Option<&[u8]>,
         svn_rev_props: &FHashMap<Vec<u8>, Vec<u8>>,
     ) -> Result<GitCommitMeta, String> {
-        let jinja_ctx = JinjaCtx::new(svn_uuid, svn_rev_no, svn_path, svn_rev_props, self.user_map);
+        let jinja_ctx = JinjaCtx::new(
+            svn_uuid,
+            svn_url,
+            svn_rev_no,
+            svn_path,
+            svn_rev_props,
+            self.user_map,
+        );
 
         let (author_name, author_email) = self.convert_author(
             &jinja_ctx,
@@ -82,12 +90,14 @@ impl crate::convert::GitMetaMaker for GitMetadataMaker<'_> {
     fn make_git_tag_meta(
         &self,
         svn_uuid: Option<&uuid::Uuid>,
+        svn_url: String,
         svn_rev_no: u32,
         svn_path: &[u8],
         svn_rev_props: &FHashMap<Vec<u8>, Vec<u8>>,
     ) -> Result<GitTagMeta, String> {
         let jinja_ctx = JinjaCtx::new(
             svn_uuid,
+            svn_url,
             svn_rev_no,
             Some(svn_path),
             svn_rev_props,
@@ -174,6 +184,7 @@ impl GitMetadataMaker<'_> {
 struct JinjaCtx {
     svn_uuid: String,
     svn_rev: u32,
+    svn_url: String,
     svn_author: String,
     svn_log: String,
     svn_path: String,
@@ -184,6 +195,7 @@ struct JinjaCtx {
 impl JinjaCtx {
     fn new(
         uuid: Option<&uuid::Uuid>,
+        url: String,
         rev_no: u32,
         branch_path: Option<&[u8]>,
         svn_rev_props: &FHashMap<Vec<u8>, Vec<u8>>,
@@ -204,6 +216,7 @@ impl JinjaCtx {
 
         Self {
             svn_uuid: uuid.map(ToString::to_string).unwrap_or_default(),
+            svn_url: url,
             svn_rev: rev_no,
             svn_log: String::from_utf8_lossy(svn_log.unwrap_or_default()).into_owned(),
             svn_author: String::from_utf8_lossy(svn_author.unwrap_or_default()).into_owned(),

--- a/src/params_file.rs
+++ b/src/params_file.rs
@@ -4,10 +4,8 @@ use std::path::PathBuf;
 #[derive(serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct ConvParams {
-    #[serde(rename = "git-svn-mode", default = "false_")]
-    pub(crate) git_svn_mode: bool,
-    #[serde(rename = "git-svn-url")]
-    pub(crate) git_svn_url: Option<String>,
+    #[serde(rename = "git-svn")]
+    pub(crate) git_svn: Option<GitSvnParams>,
     #[serde(default)]
     pub(crate) branches: Vec<String>,
     #[serde(rename = "rename-branches", default)]
@@ -54,6 +52,12 @@ pub(crate) struct ConvParams {
 pub(crate) struct BranchRev {
     pub(crate) path: String,
     pub(crate) rev: u32,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct GitSvnParams {
+    pub(crate) url: String,
 }
 
 #[inline(always)]

--- a/src/params_file.rs
+++ b/src/params_file.rs
@@ -4,6 +4,8 @@ use std::path::PathBuf;
 #[derive(serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct ConvParams {
+    #[serde(rename = "git-svn")]
+    pub(crate) git_svn: Option<GitSvnParams>,
     #[serde(default)]
     pub(crate) branches: Vec<String>,
     #[serde(rename = "rename-branches", default)]
@@ -50,6 +52,12 @@ pub(crate) struct ConvParams {
 pub(crate) struct BranchRev {
     pub(crate) path: String,
     pub(crate) rev: u32,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct GitSvnParams {
+    pub(crate) url: String,
 }
 
 #[inline(always)]

--- a/src/params_file.rs
+++ b/src/params_file.rs
@@ -58,6 +58,8 @@ pub(crate) struct BranchRev {
 #[serde(deny_unknown_fields)]
 pub(crate) struct GitSvnParams {
     pub(crate) url: String,
+    #[serde(rename = "remote-name", default = "default_remote_name")]
+    pub(crate) remote_name: String,
 }
 
 #[inline(always)]
@@ -68,4 +70,9 @@ fn false_() -> bool {
 #[inline(always)]
 fn true_() -> bool {
     true
+}
+
+#[inline(always)]
+fn default_remote_name() -> String {
+    "origin".to_string()
 }


### PR DESCRIPTION
Together with my colleague, I am working on this task (https://github.com/eduardosm/svn2git/issues/93#issuecomment-3898556222). We need to migrate a large SVN repository while still being able to work with `git svn`. Therefore, the following changes have been introduced to this branch https://github.com/eduardosm/svn2git/tree/git-svn-mode. 
A `[git-svn]` section has been added.
In the `[git-svn]` section, the parameters `url` and `remote-name` have been added.
The default value for `remote-name` is `origin`.
Additionally, a function to add the `[svn-remote "svn"]` section to the config file has been added.
An algorithm for converting a bare repository into a working copy has been found:
1. In the obtained folder, create a `.git` folder and move all files there.
2. In the config file, change the value of bare to false in the `[core]` section.
3. After that, run the command `git reset --hard` in the terminal.